### PR TITLE
slackにお問い合わせの通知がいくように変更

### DIFF
--- a/contact.py
+++ b/contact.py
@@ -1,0 +1,22 @@
+
+
+class Contact:
+	"""
+	Contact class
+
+	Attributes:
+		_thread_map (dict): map of user ID to slack contact thread
+	"""
+	_thread_map = dict()
+
+	def __init__(self) -> None:
+		pass
+
+	def register(self, user_id, thread_ts):
+		self._set_thread(user_id, thread_ts)
+
+	def _set_thread(self, user_id, thread_ts):
+		self._thread_map[user_id] = thread_ts
+
+	def get_thread(self, user_id):
+		return self._thread_map.get(user_id)

--- a/slack.py
+++ b/slack.py
@@ -1,16 +1,18 @@
+from slack_sdk import WebClient
 import requests
 
 import config
-
-CHANNEL = 'api-test'
-
-URL = "https://slack.com/api/chat.postMessage"
-HEADERS = {"Authorization": "Bearer " + config.SLACK_TOKEN}
+import contact
 
 
-def send_msg(msg):
-    data = {
-        'channel': CHANNEL,
-        'text': msg
-    }
-    requests.post(URL, headers=HEADERS, data=data)
+# Load channel from config?
+channel = '#api'
+token = config.SLACK_TOKEN
+client = WebClient(token=token)
+
+
+def start_contact(name):
+    return client.chat_postMessage(channel=channel, text=name + 'さんからお問い合わせがありました！')
+        
+def send_msg_to_thread(name, content, ts):
+    client.chat_postMessage(channel=channel, text=name + 'さんからのお問い合わせ内容：\n' + content, thread_ts=ts)


### PR DESCRIPTION
- Add: Contact class
- Add: slack thread to contact

## Purpose
- slackのスレッドにお問い合わせ内容をまとめて表示したい！ので、slack_sdkを使って、その部分を実装。
<img width="821" alt="スクリーンショット 2021-12-23 16 35 06" src="https://user-images.githubusercontent.com/34294957/147232399-e7937e12-a87e-4217-87d1-671f41d99bb9.png">


- `Contact`クラスを作成して、`user_id`と`thread_id`を関連づけるdictを実装。

- お問い合わせの処理を、開始、内容の取得みたいな感じで分割。


## Memo
- slackからの返信も受信したい！！！