### PR TITLE
Slack のお問い合わせの返信内容をLINEに反映させる

### DIFF
--- a/contact.py
+++ b/contact.py
@@ -8,15 +8,23 @@ class Contact:
 		_thread_map (dict): map of user ID to slack contact thread
 	"""
 	_thread_map = dict()
+	_user_id_map = dict()
 
 	def __init__(self) -> None:
 		pass
 
 	def register(self, user_id, thread_ts):
 		self._set_thread(user_id, thread_ts)
+		self._set_user(user_id, thread_ts)
 
 	def _set_thread(self, user_id, thread_ts):
 		self._thread_map[user_id] = thread_ts
 
+	def _set_user(self, user_id, thread_ts):
+		self._user_id_map[thread_ts] = user_id
+
 	def get_thread(self, user_id):
 		return self._thread_map.get(user_id)
+
+	def get_user(self, thread_ts):
+		return self._user_id_map.get(thread_ts)

--- a/contact.py
+++ b/contact.py
@@ -7,11 +7,10 @@ class Contact:
 	Attributes:
 		_thread_map (dict): map of user ID to slack contact thread
 	"""
-	_thread_map = dict()
-	_user_id_map = dict()
 
 	def __init__(self) -> None:
-		pass
+		self._thread_map = dict()
+		self._user_id_map = dict()
 
 	def register(self, user_id, thread_ts):
 		self._set_thread(user_id, thread_ts)


### PR DESCRIPTION
## Purpose
- LINEから受信したお問い合わせをSlack内でスレッド化し、管理している。
- 今回、それに対する返信をLINEに反映させるよにした。
- `thread_id`をkey, `user_id`をvalueとした辞書を`Contact`クラスに追加し、その人が関連するスレッド内の返信のみ、LINEに反映するようにした。
- また、`Slack bot`のeventに反応しないように、`if 'bot_id' not in event`という条件をつけている。なので、Bot以外であれば誰でもそのスレッドに返信して、お問い合わせに対応することが可能（なはず。。。）
<img width="823" alt="スクリーンショット 2021-12-23 23 35 24" src="https://user-images.githubusercontent.com/34294957/147254816-12d93b4c-d8ba-4f49-8160-d23dccec02dc.png">


## Test
```bash
ngrok http 8000
python app.py
```

URLの設定
- LINE API にngrokの`https***/callback`
- Slack API にngrokの`https***`


## Memo
- SlackのワークスペースにBot、僕、タクミさんみたいな感じで、複数人が返信返してみるテストもしてみたいっす