### PR TITLE
各機能において、Spread Sheetに書き込む際のバグを修正

### DIFF
--- a/spreadsheet.py
+++ b/spreadsheet.py
@@ -1,6 +1,6 @@
 from gspread_dataframe import set_with_dataframe
 import pandas as pd
-from models.status_type import StatusType
+from models.status_type import StatusType, is_included
 from datetime import datetime
 
 from models.user import User
@@ -22,10 +22,12 @@ def record_goal_rate(user: User, worksheet, goal):
 
     if ss_type == StatusType.CATCH_REC:
         rec_type = 'ロールモデルマッチング'
-    elif ss_type in (
-            StatusType.BN_CREATE,
-            StatusType.BN_CREATE_TRACK1, StatusType.BN_CREATE_TRACK2, StatusType.BN_CREATE_TRACK3, StatusType.BN_CREATE_TRACK5):
+    elif is_included(StatusType.BN_CREATE, ss_type):
         rec_type = '記事作成'
+    elif is_included(StatusType.SELF_REF, ss_type):
+        rec_type = '自己分析'
+    else:
+        return
 
     df_goal_rate = pd.Series([rec_type, goal, elapsed_time.total_seconds()], index=['type', 'goal', 'elapsed_time [s]'])
     df = df.append(df_goal_rate, ignore_index=True)

--- a/text_handler/stage0.py
+++ b/text_handler/stage0.py
@@ -14,6 +14,7 @@ from models.status_type import StatusType
 def stage0(line_bot_api, user, event):
     text = event.message.text
     user_id = event.source.user_id
+    user.set_session_start_timestamp()
     if text == ms.self_ref.KEY:
         line_bot_api.reply_message(event.reply_token, TextSendMessage(text=ms.self_ref.START))
         line_bot_api.push_message(user_id, ms.self_ref.M_1)


### PR DESCRIPTION
## Purpose
- ユーザーが各機能を使い始めた際(stage0)のタイムスタンプが無いと、`spreadsheet`moduleの`record_goal_rate()`関数が存在しないタイムスタンプを取得しようとしてエラーが起きていた。
    - そのため、`stage0()`の最初に`user.set_session_start_timestamp()`を実行し、各ユーザーのタイムスタンプを記録するようにした。

- `record_goal_rate()`内において、`ロールモデル`, `記事作成`に対するスプレッドシートの処理は記述していたが、それ以外の機能については何も書いていなかったため、書き込みに失敗していた。
    - どの処理かを、`StatusType`及び`is_included()`という神関数を用いて判断し、スプレッドシートに記録するようにした。
    - 現状、`お問い合わせ`機能に関しては、中断か終了か判断できないため、スプレッドシートには何も記録せず、そのまま終了するだけにした。

## Effect
- 各機能についての記録が、エラーなくスプレッドシートに記録できるようになったはず・・・！