### PR TITLE
新規タグの質問が用意されていなかった際の処理を追加

### DIFF
--- a/const/question.py
+++ b/const/question.py
@@ -39,4 +39,4 @@ questions[24] = QUESTION_24
 questions[12] = QUESTION_12
 questions[17] = QUESTION_17
 questions[31] = QUESTION_31
-# questions[35] = QUESTION_35
+questions[35] = QUESTION_35

--- a/const/question.py
+++ b/const/question.py
@@ -39,4 +39,4 @@ questions[24] = QUESTION_24
 questions[12] = QUESTION_12
 questions[17] = QUESTION_17
 questions[31] = QUESTION_31
-questions[35] = QUESTION_35
+# questions[35] = QUESTION_35

--- a/slack.py
+++ b/slack.py
@@ -52,3 +52,7 @@ def start_bn_creation(name):
 
 def start_catcher_rec(name):
     return send_message(name + 'さんがロールモデルマッチングを始めました！')
+
+
+def tag_missing(tag_id):
+    return send_message(f'{tag_id}番のタグが見つかりませんでした...')

--- a/slack.py
+++ b/slack.py
@@ -55,4 +55,4 @@ def start_catcher_rec(name):
 
 
 def tag_missing(tag_id):
-    return send_message(f'{tag_id}番のタグが見つかりませんでした...')
+    return send_message(f'{tag_id}番のタグの質問が見つかりませんでした...')


### PR DESCRIPTION
## Purpose

- 今までは新規社会人をウェブサイトで掲載して、新しいタグが追加されていなかった時に、const/question.pyに急いでタグを追加する必要があった
- 質問が存在しなかった時はその質問に`No`という回答をもらった時と同じようにする処理を追加した
- その上で、その旨をslackで連絡するようにした

- あと、不必要に`list`を使っているところがあったので、`set`に変更した 

## Effect
以下のような連絡がslackにくる。ユーザー側に特に違いは起きない。
![スクリーンショット 2022-01-16 20 07 02](https://user-images.githubusercontent.com/69781798/149657384-c80a8371-50b1-49f3-b448-cc293034c4aa.png)

