### PR TITLE
自己分析機能において、Slackにメッセージが多重に送られてくる問題を修正

### DIFF
--- a/text_handler/self_ref_exp.py
+++ b/text_handler/self_ref_exp.py
@@ -9,8 +9,9 @@ def self_ref_exp(line_bot_api, user, event):
     text = event.message.text
     ss_stage = user.get_session_stage()
     if ss_stage == 3:
-        slack.send_msg_to_other_thread(user)
-        user.reset_answer_msg()
+        if text in ['Yes', 'No']:
+            slack.send_msg_to_other_thread(user)
+            user.reset_answer_msg()
         if text == 'Yes':
             user.set_session_stage(5)
             line_bot_api.reply_message(event.reply_token, TextSendMessage(text=ms.self_ref.EXP_3_YES))

--- a/text_handler/self_ref_pers.py
+++ b/text_handler/self_ref_pers.py
@@ -9,8 +9,9 @@ def self_ref_pers(line_bot_api, user, event):
     text = event.message.text
     ss_stage = user.get_session_stage()
     if ss_stage == 3:
-        slack.send_msg_to_other_thread(user)
-        user.reset_answer_msg()
+        if text in ['Yes', 'No']:
+            slack.send_msg_to_other_thread(user)
+            user.reset_answer_msg()
         if text == 'Yes':
             user.set_session_stage(5)
             line_bot_api.reply_message(event.reply_token, TextSendMessage(text=ms.self_ref.PERS_3_YES))
@@ -21,8 +22,9 @@ def self_ref_pers(line_bot_api, user, event):
             line_bot_api.push_message(user.get_id(), TextSendMessage(text=ms.self_ref.PERS_3_NO_EX))
             user.set_question_msg(ms.self_ref.PERS_3_NO + '\n' + ms.self_ref.PERS_3_NO_EX)
     elif ss_stage == 7:
-        slack.send_msg_to_other_thread(user)
-        user.reset_answer_msg()
+        if text in ['Yes', 'No']:
+            slack.send_msg_to_other_thread(user)
+            user.reset_answer_msg()
         if text == 'Yes':
             user.set_session_stage(8)
             line_bot_api.reply_message(event.reply_token, TextSendMessage(text=ms.self_ref.PERS_7_YES))

--- a/text_handler/self_ref_vis.py
+++ b/text_handler/self_ref_vis.py
@@ -9,8 +9,9 @@ def self_ref_vis(line_bot_api, user, event):
     text = event.message.text
     ss_stage = user.get_session_stage()
     if ss_stage == 3:
-        slack.send_msg_to_other_thread(user)
-        user.reset_answer_msg()
+        if text in ['Yes', 'No']:
+            slack.send_msg_to_other_thread(user)
+            user.reset_answer_msg()
         if text == 'Yes':
             user.set_session_stage(9)
             line_bot_api.reply_message(event.reply_token, TextSendMessage(text=ms.self_ref.VIS_3_YES))
@@ -21,9 +22,10 @@ def self_ref_vis(line_bot_api, user, event):
             line_bot_api.reply_message(event.reply_token, TextSendMessage(text=ms.self_ref.VIS_3_NO))
             line_bot_api.push_message(user.get_id(), TextSendMessage(text=ms.default.ASK_FOR_NEXT))
             user.set_question_msg(ms.self_ref.VIS_3_NO + '\n' + ms.default.ASK_FOR_NEXT)
-    if ss_stage == 10:
-        slack.send_msg_to_other_thread(user)
-        user.reset_answer_msg()
+    elif ss_stage == 10:
+        if text in ['Yes', 'No']:
+            slack.send_msg_to_other_thread(user)
+            user.reset_answer_msg()
         if text == 'Yes':
             user.set_session_stage(12)
             line_bot_api.reply_message(event.reply_token, TextSendMessage(text=ms.self_ref.VIS_10_YES))


### PR DESCRIPTION
## Purpose
- 下記のように`stage`が`Yes/No`で答える質問にきた場合、どんなテキストが来てもユーザーの入力した内容をSlackに送るようにしていた。

```python
def self_ref_vis(line_bot_api, user, event):
    text = event.message.text
    ss_stage = user.get_session_stage()
    if ss_stage == 3:
        slack.send_msg_to_other_thread(user)
        user.reset_answer_msg()
```

- 同じ質問に対して、多重にメッセージが送られてくるのは煩わしいので、以下のように規定のテキストが入力されたのをトリガーにしてSlackにメッセージを送るようにした。
```python
def self_ref_vis(line_bot_api, user, event):
    text = event.message.text
    ss_stage = user.get_session_stage()
    if ss_stage == 3:
        if text in ['Yes', 'No']:
            slack.send_msg_to_other_thread(user)
            user.reset_answer_msg()
```

## Effect
- 特定の質問に対して、多重にメッセージ送られてくる問題はなくなるはず。。。
- `Yes/No`を答えてもらう質問に関しては、`次`はトリガーにせず、`Yes/No`のみをメッセージを送るトリガーとした。

## Memo
- 自分でのデバッグのときに気づけんかったっす。申し訳ない。。。